### PR TITLE
Add dark theme and navigation improvements

### DIFF
--- a/steevehusser/src/app/app.component.html
+++ b/steevehusser/src/app/app.component.html
@@ -1,5 +1,5 @@
 <div class="portfolio-container">
-  <app-navbar [title]="title" (navigate)="scrollToSection($event)"></app-navbar>
+  <app-navbar [title]="title" [active]="activeSection" (navigate)="scrollToSection($event)"></app-navbar>
   <app-hero [title]="title" [particles]="particles" (contact)="scrollToSection('contact')"></app-hero>
   <app-about [visible]="isVisible.about"></app-about>
   <app-skills [skills]="skills" [visible]="isVisible.skills"></app-skills>

--- a/steevehusser/src/app/app.component.ts
+++ b/steevehusser/src/app/app.component.ts
@@ -72,6 +72,8 @@ export class AppComponent implements OnInit {
     contact: false
   };
 
+  activeSection = '';
+
   particles = Array.from({ length: 18 });
 
   constructor(@Inject(PLATFORM_ID) private platformId: Object) { }
@@ -95,14 +97,19 @@ export class AppComponent implements OnInit {
     }
 
     const sections = ['about', 'skills', 'experience', 'projects', 'contact'];
+    let current = this.activeSection;
     sections.forEach(section => {
       const element = document.getElementById(section);
       if (element) {
         const rect = element.getBoundingClientRect();
         const isVisible = rect.top < window.innerHeight && rect.bottom > 0;
         this.isVisible[section as keyof typeof this.isVisible] = isVisible;
+        if (rect.top <= window.innerHeight / 2 && rect.bottom >= window.innerHeight / 2) {
+          current = section;
+        }
       }
     });
+    this.activeSection = current;
   }
 
   scrollToSection(sectionId: string) {

--- a/steevehusser/src/app/components/hero.component.scss
+++ b/steevehusser/src/app/components/hero.component.scss
@@ -7,6 +7,8 @@
     position: relative;
     overflow: hidden;
     padding: 2rem;
+    background: var(--primary-gradient);
+    background-attachment: fixed;
 
     &::before {
         content: '';

--- a/steevehusser/src/app/components/hero.component.ts
+++ b/steevehusser/src/app/components/hero.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ViewEncapsulation, HostListener } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -16,5 +16,13 @@ export class HeroComponent {
 
   scrollToContact() {
     this.contact.emit();
+  }
+
+  @HostListener('window:scroll')
+  onWindowScroll() {
+    const hero = document.querySelector('.hero-section') as HTMLElement;
+    if (hero) {
+      hero.style.backgroundPositionY = `${-window.pageYOffset * 0.3}px`;
+    }
   }
 }

--- a/steevehusser/src/app/components/navbar.component.html
+++ b/steevehusser/src/app/components/navbar.component.html
@@ -1,10 +1,11 @@
 <nav class="navbar">
   <div class="nav-brand">{{ title }}</div>
   <div class="nav-links">
-    <a (click)="scrollTo('about')" class="nav-link">À propos</a>
-    <a (click)="scrollTo('skills')" class="nav-link">Compétences</a>
-    <a (click)="scrollTo('experience')" class="nav-link">Expérience</a>
-    <a (click)="scrollTo('projects')" class="nav-link">Projets</a>
-    <a (click)="scrollTo('contact')" class="nav-link">Contact</a>
+    <a (click)="scrollTo('about')" class="nav-link" [class.active]="active === 'about'">À propos</a>
+    <a (click)="scrollTo('skills')" class="nav-link" [class.active]="active === 'skills'">Compétences</a>
+    <a (click)="scrollTo('experience')" class="nav-link" [class.active]="active === 'experience'">Expérience</a>
+    <a (click)="scrollTo('projects')" class="nav-link" [class.active]="active === 'projects'">Projets</a>
+    <a (click)="scrollTo('contact')" class="nav-link" [class.active]="active === 'contact'">Contact</a>
   </div>
+  <button class="theme-toggle" (click)="toggleTheme()">{{ isDark ? '☀️' : '🌙' }}</button>
 </nav>

--- a/steevehusser/src/app/components/navbar.component.scss
+++ b/steevehusser/src/app/components/navbar.component.scss
@@ -62,9 +62,28 @@
                 transition: width 0.3s ease;
             }
 
-            &:hover::after {
+            &:hover::after,
+            &.active::after {
                 width: 80%;
             }
+
+            &.active {
+                color: var(--warm-pink);
+            }
+        }
+    }
+
+    .theme-toggle {
+        background: none;
+        border: none;
+        cursor: pointer;
+        font-size: 1.4rem;
+        margin-left: 1rem;
+        color: var(--text-dark);
+        transition: color 0.3s;
+
+        &:hover {
+            color: var(--warm-pink);
         }
     }
 }

--- a/steevehusser/src/app/components/navbar.component.ts
+++ b/steevehusser/src/app/components/navbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, Input, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, Output, Input, ViewEncapsulation, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -9,9 +9,28 @@ import { CommonModule } from '@angular/common';
   styleUrl: './navbar.component.scss',
   encapsulation: ViewEncapsulation.None
 })
-export class NavbarComponent {
+export class NavbarComponent implements OnInit {
   @Input() title = '';
+  @Input() active = '';
   @Output() navigate = new EventEmitter<string>();
+
+  isDark = false;
+
+  ngOnInit() {
+    const stored = localStorage.getItem('theme');
+    this.isDark = stored ? stored === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
+    this.applyTheme();
+  }
+
+  toggleTheme() {
+    this.isDark = !this.isDark;
+    localStorage.setItem('theme', this.isDark ? 'dark' : 'light');
+    this.applyTheme();
+  }
+
+  private applyTheme() {
+    document.body.classList.toggle('dark-theme', this.isDark);
+  }
 
   scrollTo(section: string) {
     this.navigate.emit(section);

--- a/steevehusser/src/styles.scss
+++ b/steevehusser/src/styles.scss
@@ -22,6 +22,7 @@
     --text-dark: #2d3748;
     --text-warm: #4a5568;
     --text-light: #718096;
+    --bg-white: #ffffff;
     --bg-warm: #fef5e7;
     --bg-glass: rgba(255, 255, 255, 0.25);
     --bg-card: rgba(255, 255, 255, 0.9);
@@ -34,6 +35,16 @@
     --border-radius-md: 20px;
     --border-radius-lg: 30px;
     --border-radius-xl: 50px;
+}
+
+/* Variables pour le mode sombre */
+body.dark-theme {
+    --bg-white: #1a202c;
+    --bg-warm: #2d3748;
+    --text-dark: #f7fafc;
+    --text-warm: #e2e8f0;
+    --bg-glass: rgba(45, 55, 72, 0.25);
+    --bg-card: rgba(45, 55, 72, 0.9);
 }
 
 // Reset global amélioré


### PR DESCRIPTION
## Summary
- define `--bg-white` and dark theme variables
- implement dark mode toggle in navbar
- highlight navigation links for current section
- add parallax scroll effect on hero background

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430fa5b9448328961935bf045acc88