### PR TITLE
Clarify 500 CAD starting price

### DIFF
--- a/steevehusser/src/app/app.component.html
+++ b/steevehusser/src/app/app.component.html
@@ -5,6 +5,7 @@
   <app-skills [skills]="skills" [visible]="isVisible.skills"></app-skills>
   <app-experience [experiences]="experiences" [visible]="isVisible.experience"></app-experience>
   <app-projects [visible]="isVisible.projects" (contact)="scrollToSection('contact')"></app-projects>
+  <app-pricing [visible]="isVisible.pricing" (contact)="scrollToSection('contact')"></app-pricing>
   <app-contact [visible]="isVisible.contact"></app-contact>
   <app-footer [title]="title"></app-footer>
 </div>

--- a/steevehusser/src/app/app.component.ts
+++ b/steevehusser/src/app/app.component.ts
@@ -8,6 +8,7 @@ import { AboutComponent } from './components/about.component';
 import { SkillsComponent } from './components/skills.component';
 import { ExperienceComponent } from './components/experience.component';
 import { ProjectsComponent } from './components/projects.component';
+import { PricingComponent } from './components/pricing.component';
 import { ContactComponent } from './components/contact.component';
 import { FooterComponent } from './components/footer.component';
 
@@ -24,6 +25,7 @@ import { FooterComponent } from './components/footer.component';
     SkillsComponent,
     ExperienceComponent,
     ProjectsComponent,
+    PricingComponent,
     ContactComponent,
     FooterComponent
   ],
@@ -69,6 +71,7 @@ export class AppComponent implements OnInit {
     skills: false,
     experience: false,
     projects: false,
+    pricing: false,
     contact: false
   };
 
@@ -94,7 +97,7 @@ export class AppComponent implements OnInit {
       return;
     }
 
-    const sections = ['about', 'skills', 'experience', 'projects', 'contact'];
+    const sections = ['about', 'skills', 'experience', 'projects', 'pricing', 'contact'];
     sections.forEach(section => {
       const element = document.getElementById(section);
       if (element) {

--- a/steevehusser/src/app/components/about.component.html
+++ b/steevehusser/src/app/components/about.component.html
@@ -13,6 +13,9 @@
           techniques et collaborer sur des projets ambitieux. Mon approche combine rigueur technique
           et créativité pour livrer des applications de qualité.
         </p>
+        <p class="about-paragraph highlight-offer">
+          Je propose la création de sites vitrines sur mesure à un tarif préférentiel à partir de 500&nbsp;CAD afin de rendre le web accessible à tous.
+        </p>
         <div class="about-highlights">
           <div class="highlight-item">
             <span class="highlight-icon">🎯</span>

--- a/steevehusser/src/app/components/about.component.scss
+++ b/steevehusser/src/app/components/about.component.scss
@@ -29,6 +29,14 @@
         font-weight: 500;
     }
 
+    .highlight-offer {
+        background: var(--warm-gradient);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+        font-weight: 700;
+    }
+
     .about-highlights {
         display: flex;
         justify-content: center;

--- a/steevehusser/src/app/components/contact.component.html
+++ b/steevehusser/src/app/components/contact.component.html
@@ -4,7 +4,7 @@
     <div class="contact-content">
       <div class="contact-info">
         <h3>Parlons de votre projet</h3>
-        <p>N'hésitez pas à me contacter pour discuter de vos besoins ou simplement échanger sur vos idées.</p>
+          <p>N'hésitez pas à me contacter pour discuter de votre futur site web. <strong>Offre spéciale : site vitrine complet à partir de 500&nbsp;CAD&nbsp;!</strong></p>
         <div class="contact-methods">
           <button class="contact-method" (click)="sendEmail()">
             <span class="method-icon">📧</span>

--- a/steevehusser/src/app/components/hero.component.html
+++ b/steevehusser/src/app/components/hero.component.html
@@ -1,4 +1,5 @@
 <header class="hero-section">
+  <div class="offer-banner">Offre limitée : site vitrine professionnel à partir de 500&nbsp;CAD&nbsp;!</div>
   <div class="hero-content hero-content-row">
     <div class="hero-avatar-halo">
       <div class="avatar-halo"></div>
@@ -10,6 +11,7 @@
       <h1 class="hero-title-sobre">{{ title }}</h1>
       <h2 class="hero-subtitle">Développeur Full Stack</h2>
       <p class="hero-slogan">Passionné par l'innovation, prêt à relever de nouveaux défis</p>
+<p class="hero-offer">Votre site web clé en main à partir de 500&nbsp;CAD</p>
       <div class="hero-stats">
         <div class="stat-item">
           <span class="stat-number">10+</span>

--- a/steevehusser/src/app/components/hero.component.scss
+++ b/steevehusser/src/app/components/hero.component.scss
@@ -25,6 +25,32 @@
         max-width: 900px;
         position: relative;
     }
+
+    .offer-banner {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        padding: 1rem;
+        background: var(--warm-gradient);
+        color: white;
+        font-weight: 700;
+        text-align: center;
+        letter-spacing: 1px;
+        animation: bannerPulse 4s infinite;
+    }
+}
+
+@keyframes bannerPulse {
+    0% {
+        opacity: 0.8;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0.8;
+    }
 }
 
 .hero-content-row {
@@ -211,6 +237,24 @@
         transform: translateX(50px);
     }
 
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+.hero-offer {
+    font-size: 1.2rem;
+    color: var(--warm-pink);
+    margin-bottom: 2rem;
+    font-weight: 600;
+    animation: offerSlideIn 1s ease-out 0.45s both;
+}
+
+@keyframes offerSlideIn {
+    from {
+        opacity: 0;
+        transform: translateX(50px);
+    }
     to {
         opacity: 1;
         transform: translateX(0);

--- a/steevehusser/src/app/components/pricing.component.html
+++ b/steevehusser/src/app/components/pricing.component.html
@@ -1,0 +1,17 @@
+<section id="pricing" class="section pricing-section" [class.visible]="visible">
+  <div class="container">
+    <h2 class="section-title">Offre Spéciale</h2>
+    <div class="pricing-card">
+      <div class="price-circle">
+        <span class="price-from">À partir de</span>
+        <span class="price-amount">500 CAD</span>
+        <span class="price-label">Site vitrine</span>
+      </div>
+      <p class="pricing-details">
+        Création de site web moderne, responsive et optimisé pour le référencement.
+        Idéal pour mettre en valeur votre activité à moindre coût.
+      </p>
+      <button class="project-cta" (click)="openContact()">Profiter de l'offre</button>
+    </div>
+  </div>
+</section>

--- a/steevehusser/src/app/components/pricing.component.scss
+++ b/steevehusser/src/app/components/pricing.component.scss
@@ -1,0 +1,59 @@
+// Pricing Section
+.pricing-section {
+  position: relative;
+  background: var(--bg-warm);
+
+  .pricing-card {
+    background: var(--bg-card);
+    backdrop-filter: blur(20px);
+    padding: 4rem 3rem;
+    border-radius: 30px;
+    text-align: center;
+    box-shadow: var(--shadow-warm);
+    max-width: 600px;
+    margin: 0 auto;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .price-circle {
+    width: 180px;
+    height: 180px;
+    border-radius: 50%;
+    background: var(--warm-gradient);
+    color: white;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    font-weight: 800;
+    margin: 0 auto 2rem;
+    box-shadow: var(--shadow-pink);
+  }
+
+  .price-from {
+    font-size: 0.9rem;
+    margin-bottom: 0.25rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+
+  .price-amount {
+    font-size: 2.2rem;
+    line-height: 1;
+  }
+
+  .price-label {
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+
+  .pricing-details {
+    font-size: 1.2rem;
+    line-height: 1.6;
+    color: var(--text-dark);
+    margin-bottom: 2rem;
+  }
+}

--- a/steevehusser/src/app/components/pricing.component.ts
+++ b/steevehusser/src/app/components/pricing.component.ts
@@ -1,0 +1,19 @@
+import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-pricing',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './pricing.component.html',
+  styleUrl: './pricing.component.scss',
+  encapsulation: ViewEncapsulation.None
+})
+export class PricingComponent {
+  @Input() visible = false;
+  @Output() contact = new EventEmitter<void>();
+
+  openContact() {
+    this.contact.emit();
+  }
+}

--- a/steevehusser/src/index.html
+++ b/steevehusser/src/index.html
@@ -6,8 +6,7 @@
   <title>Steeve Husser - Développeur Full Stack</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description"
-    content="Steeve Husser - Développeur Full Stack avec plus de 10 ans d'expérience en .NET, Angular, SQL et développement mobile. Disponible pour projets freelance.">
+    <meta name="description" content="Steeve Husser - Développeur Full Stack. Offre spéciale : sites web professionnels à partir de 500 CAD, moins chers que le marché. Plus de 10 ans d'experience en .NET, Angular, SQL et développement mobile. Disponible pour projets freelance.">
   <meta name="keywords" content="développeur, full stack, .NET, Angular, SQL, freelance, développement web, mobile">
   <meta name="author" content="Steeve Husser">
 
@@ -15,15 +14,12 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://steevehusserhub.io/">
   <meta property="og:title" content="Steeve Husser - Développeur Full Stack">
-  <meta property="og:description"
-    content="Développeur Full Stack passionné avec plus de 10 ans d'expérience. Spécialisé en .NET, Angular, SQL et développement mobile.">
-
+    <meta property="og:description" content="Offre spéciale : sites web professionnels à partir de 500 CAD, moins chers que le marché. Plus de 10 ans d'experience en .NET, Angular, SQL et développement mobile.">
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
   <meta property="twitter:url" content="https://steevehusserhub.io/">
   <meta property="twitter:title" content="Steeve Husser - Développeur Full Stack">
-  <meta property="twitter:description"
-    content="Développeur Full Stack passionné avec plus de 10 ans d'expérience. Spécialisé en .NET, Angular, SQL et développement mobile.">
+    <meta property="twitter:description" content="Offre spéciale : sites web professionnels à partir de 500 CAD, moins chers que le marché. Plus de 10 ans d'experience en .NET, Angular, SQL et développement mobile.">
 
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 


### PR DESCRIPTION
## Summary
- update hero banner and tagline with "à partir de 500 CAD"
- highlight starting price in About and Contact sections
- show "À partir de" text in Pricing component with new CSS

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431e9983d88328ac81e9beabe214aa